### PR TITLE
feat: add failureThreshold to probes

### DIFF
--- a/charts/be-multisvc/Chart.yaml
+++ b/charts/be-multisvc/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-multisvc
 description: Generic multi service BE application
 
-version: 0.7.0
+version: 0.7.1
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-multisvc/templates/deployment.yaml
+++ b/charts/be-multisvc/templates/deployment.yaml
@@ -82,6 +82,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
@@ -93,6 +94,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.startup.enabled }}
@@ -104,6 +106,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/be-multisvc/templates/worker.yaml
+++ b/charts/be-multisvc/templates/worker.yaml
@@ -96,6 +96,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .probes.readiness }}
@@ -107,6 +108,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .probes.startup }}
@@ -118,6 +120,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .resources | default $.Values.resources }}

--- a/charts/be-multisvc/values.yaml
+++ b/charts/be-multisvc/values.yaml
@@ -48,6 +48,7 @@ probes:
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
   readiness:
     enabled: false
     path: /_health
@@ -55,6 +56,7 @@ probes:
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
   startup:
     enabled: false
     path: /_health
@@ -62,6 +64,7 @@ probes:
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
 
 ingresses:
   web:

--- a/charts/be-multisvc/values.yaml
+++ b/charts/be-multisvc/values.yaml
@@ -201,10 +201,23 @@ workers: {}
   #       initialDelaySeconds: 30
   #       periodSeconds: 10
   #       timeoutSeconds: 5
+  #       failureThreshold: 3
   #     readiness:
   #       enabled: false
+  #       path: /_ready
+  #       port: "8000"
+  #       initialDelaySeconds: 30
+  #       periodSeconds: 10
+  #       timeoutSeconds: 5
+  #       failureThreshold: 3
   #     startup:
   #       enabled: false
+  #       path: /_start
+  #       port: "8000"
+  #       initialDelaySeconds: 30
+  #       periodSeconds: 10
+  #       timeoutSeconds: 5
+  #       failureThreshold: 3
 
 crons: {}
   # example:

--- a/charts/be-web/Chart.yaml
+++ b/charts/be-web/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-web
 description: Generic web BE application
 
-version: 0.8.0
+version: 0.8.1
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-web/templates/deployment.yaml
+++ b/charts/be-web/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
-            failureThreshold: {{ failureThreshold }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
@@ -92,7 +92,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
-            failureThreshold: {{ failureThreshold }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.startup.enabled }}
@@ -104,7 +104,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
-            failureThreshold: {{ failureThreshold }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/be-web/templates/deployment.yaml
+++ b/charts/be-web/templates/deployment.yaml
@@ -80,6 +80,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
@@ -91,6 +92,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.startup.enabled }}
@@ -102,6 +104,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/be-web/templates/worker.yaml
+++ b/charts/be-web/templates/worker.yaml
@@ -96,6 +96,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .probes.readiness }}
@@ -107,6 +108,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .probes.startup }}
@@ -118,6 +120,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .resources | default $.Values.resources }}

--- a/charts/be-web/values.yaml
+++ b/charts/be-web/values.yaml
@@ -46,18 +46,21 @@ probes:
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
   readiness:
     enabled: false
     path: /_health
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
   startup:
     enabled: false
     path: /_health
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
 
 ingress:
   enabled: false

--- a/charts/be-web/values.yaml
+++ b/charts/be-web/values.yaml
@@ -196,10 +196,23 @@ workers: {}
   #       initialDelaySeconds: 30
   #       periodSeconds: 10
   #       timeoutSeconds: 5
+  #       failureThreshold: 3
   #     readiness:
   #       enabled: false
+  #       path: /_ready
+  #       port: "8000"
+  #       initialDelaySeconds: 30
+  #       periodSeconds: 10
+  #       timeoutSeconds: 5
+  #       failureThreshold: 3
   #     startup:
   #       enabled: false
+  #       path: /_start
+  #       port: "8000"
+  #       initialDelaySeconds: 30
+  #       periodSeconds: 10
+  #       timeoutSeconds: 5
+  #       failureThreshold: 3
 
 crons: {}
   # example:

--- a/charts/fe-nextjs/Chart.yaml
+++ b/charts/fe-nextjs/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: fe-nextjs
 description: Generic FE NextJS application
 
-version: 0.3.1
+version: 0.3.2
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/fe-nextjs/templates/deployment.yaml
+++ b/charts/fe-nextjs/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
@@ -80,6 +81,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- if .Values.probes.startup.enabled }}
@@ -91,6 +93,7 @@ spec:
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
             timeoutSeconds: {{ .timeoutSeconds }}
+            failureThreshold: {{ .failureThreshold }}
             {{- end }}
           {{- end }}
           {{- with .Values.resources }}

--- a/charts/fe-nextjs/values.yaml
+++ b/charts/fe-nextjs/values.yaml
@@ -39,18 +39,21 @@ probes:
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
   readiness:
     enabled: false
     path: /_health
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
   startup:
     enabled: false
     path: /_health
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
+    failureThreshold: 3
 
 service:
   annotations: {}


### PR DESCRIPTION
The goal of these changes is to make the probes.failureThreshold configurable in `be-multisvc` chart.