### PR TITLE
fix: k8s probes initialDelaySeconds to 0

### DIFF
--- a/charts/be-multisvc/Chart.yaml
+++ b/charts/be-multisvc/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-multisvc
 description: Generic multi service BE application
 
-version: 0.7.3
+version: 0.8.0
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-multisvc/values.yaml
+++ b/charts/be-multisvc/values.yaml
@@ -45,7 +45,7 @@ probes:
     enabled: false
     path: /_health
     port: "8000"
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
@@ -53,7 +53,7 @@ probes:
     enabled: false
     path: /_health
     port: "8000"
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
@@ -61,10 +61,10 @@ probes:
     enabled: false
     path: /_health
     port: "8000"
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
-    failureThreshold: 3
+    failureThreshold: 6
 
 ingresses:
   web:

--- a/charts/be-web/Chart.yaml
+++ b/charts/be-web/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-web
 description: Generic web BE application
 
-version: 0.8.3
+version: 0.9.0
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-web/values.yaml
+++ b/charts/be-web/values.yaml
@@ -43,24 +43,24 @@ probes:
   liveness:
     enabled: false
     path: /_health
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
   readiness:
     enabled: false
     path: /_health
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
   startup:
     enabled: false
     path: /_health
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
-    failureThreshold: 3
+    failureThreshold: 6
 
 ingress:
   enabled: false

--- a/charts/fe-nextjs/Chart.yaml
+++ b/charts/fe-nextjs/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: fe-nextjs
 description: Generic FE NextJS application
 
-version: 0.3.2
+version: 0.4.0
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/fe-nextjs/values.yaml
+++ b/charts/fe-nextjs/values.yaml
@@ -36,24 +36,24 @@ probes:
   liveness:
     enabled: false
     path: /_health
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
   readiness:
     enabled: false
     path: /_health
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
   startup:
     enabled: false
     path: /_health
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
     timeoutSeconds: 5
-    failureThreshold: 3
+    failureThreshold: 6
 
 service:
   annotations: {}


### PR DESCRIPTION
using startup probe ensure readiness and liveness probes are not checked until the application is ready to handle them. There is no need to delay them.
