### PR TITLE
Prevent collision between podmonitor and servicemonitor names

### DIFF
--- a/charts/be-multisvc/Chart.yaml
+++ b/charts/be-multisvc/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-multisvc
 description: Generic multi service BE application
 
-version: 0.11.0
+version: 0.12.0
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-multisvc/templates/podmonitor.yaml
+++ b/charts/be-multisvc/templates/podmonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "app.fullname" . }}
+  name: {{ include "app.fullname" . }}-podmonitor
   labels:
     {{- include "app.labels" . | nindent 4 }}
   {{- with .Values.podAnnotations }}
@@ -26,7 +26,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "app.fullname" $ }}-{{ $key }}
+  name: {{ include "app.fullname" $ }}-podmonitor-{{ $key }}
   labels:
     {{- include "app.labels" $ | nindent 4 }}
   {{- with $.Values.podAnnotations }}

--- a/charts/be-multisvc/templates/servicemonitor.yaml
+++ b/charts/be-multisvc/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "app.fullname" . }}
+  name: {{ include "app.fullname" . }}-servicemonitor
   labels:
     {{- include "app.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/be-web/Chart.yaml
+++ b/charts/be-web/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-web
 description: Generic web BE application
 
-version: 0.12.0
+version: 0.13.0
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-web/templates/podmonitor.yaml
+++ b/charts/be-web/templates/podmonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "app.fullname" . }}
+  name: {{ include "app.fullname" . }}-podmonitor
   labels:
     {{- include "app.labels" . | nindent 4 }}
   {{- with .Values.podAnnotations }}
@@ -26,7 +26,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "app.fullname" $ }}-{{ $key }}
+  name: {{ include "app.fullname" $ }}-podmonitor-{{ $key }}
   labels:
     {{- include "app.labels" $ | nindent 4 }}
   {{- with $.Values.podAnnotations }}

--- a/charts/be-web/templates/servicemonitor.yaml
+++ b/charts/be-web/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "app.fullname" . }}
+  name: {{ include "app.fullname" . }}-servicemonitor
   labels:
     {{- include "app.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}


### PR DESCRIPTION
This because prometheus exporter uses resources names to generate job names, and it's not possible to have more more than one job with the same name
