### PR TITLE
feat: use `batch/v1` for cronjob in be-web and be-multisvc

### DIFF
--- a/charts/be-multisvc/Chart.yaml
+++ b/charts/be-multisvc/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-multisvc
 description: Generic multi service BE application
 
-version: 0.15.2
+version: 0.16.0
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-multisvc/templates/cronjob.yaml
+++ b/charts/be-multisvc/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 {{ $cdata := dict "name" $key "cron" $val "globals" $ }}
 {{ $imgdata := .image | default $.Values.image }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "app.fullname" $ }}-cron-{{ $key | replace "_" "-" }}

--- a/charts/be-web/Chart.yaml
+++ b/charts/be-web/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 name: be-web
 description: Generic web BE application
 
-version: 0.18.0
+version: 0.19.0
 kubeVersion: ">=1.14.0-0"
 
 home: https://github.com/Casavo/charts

--- a/charts/be-web/templates/cronjob.yaml
+++ b/charts/be-web/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 {{ $cdata := dict "name" $key "cron" $val "globals" $ }}
 {{ $imgdata := .image | default $.Values.image }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "app.fullname" $ }}-cron-{{ $key | replace "_" "-" }}


### PR DESCRIPTION
to solve helm warning:

```
batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```