### PR TITLE
chore: update gh actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: v3.4.0
       - name: Render charts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: v3.4.0
       - name: Helm deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
             helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
           done
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+      - uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:


### PR DESCRIPTION
- [x] bump actions/checkout from v2 to v3
- [x] bump azure/setup-helm from v1 to v3
- [x] bump helm/chart-releaser-action from v1.4.0 to v1.5.0

misc:
- should fix deprecation warning about `set-output` command
- remove step name when using a public action