### PR TITLE
feat(ci): add Dependabot for GitHub Actions auto-upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "actions/*"
+      - dependency-name: "docker/*"
+      - dependency-name: "casavo/*"
+      - dependency-name: "hashicorp/*"
+      - dependency-name: "anthropics/*"
+      - dependency-name: "slackapi/*"
+      - dependency-name: "abatilo/*"
+


### PR DESCRIPTION
## Summary

Adds Dependabot configuration for GitHub Actions auto-upgrade.

Only trusted namespaces are included in the allow list:
- `actions/*`
- `docker/*`
- `casavo/*`
- `hashicorp/*`
- `anthropics/*`
- `slackapi/*`
- `abatilo/*`

Part of [PDO-1698](https://casavo.atlassian.net/browse/PDO-1698)

[PDO-1698]: https://casavo.atlassian.net/browse/PDO-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ